### PR TITLE
Changed the permission to content admin. Instead of hard coding the …

### DIFF
--- a/tasty_backend_base.views_default.inc
+++ b/tasty_backend_base.views_default.inc
@@ -381,8 +381,11 @@ function tasty_backend_base_default_vbo_view(&$views, $type, $name) {
   $handler->display->display_options['title'] = 'Manage ' . $name . ' content';
   $handler->display->display_options['use_ajax'] = TRUE;
   $handler->display->display_options['use_more_always'] = FALSE;
-  $handler->display->display_options['access']['type'] = 'perm';
-  $handler->display->display_options['access']['perm'] = 'edit any ' . $type . ' content';
+  $content_admin_role = user_role_load_by_name('content admin');
+  $handler->display->display_options['access']['type'] = 'role';
+  $handler->display->display_options['access']['role'] = array(
+    4 => $content_admin_role->rid,
+  );
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['query']['options']['query_comment'] = FALSE;


### PR DESCRIPTION
…rid to 4 we search for it incase other roles have been created.

I saw that some places the permissions were being assigned to anyone that can edit all content of that type and other times it was being assigned to role id, rid 4 which if no other roles were created before the module was installed would be the content admin that the tasty_backend_base would create.

I also notice that in tasty_backend_webform you went and looked up the rid for the content admin role, so I switched the assignment to this method for articles in the tasty_backend_article and for basic pages in tasty_backend_base.
